### PR TITLE
PCD-4973 : Ubuntu24 builds now working

### DIFF
--- a/build-aux/build-debs.sh
+++ b/build-aux/build-debs.sh
@@ -11,7 +11,7 @@ UBUNTU_VERSION=$1
 
 
 PF9_OVN_BUILD_VERSION=24.03.2-pf9-$PF9_VERSION-$BUILD_NUMBER
-printf '%s' "$PF9_OVN_BUILD_VERSION" > $ROOT/ovn-deb-version.txt
+printf '%s' "$PF9_OVN_BUILD_VERSION" > $TEAMCITY_ROOT/ovn-deb-version.txt
 
 sed -i "s/__PF9_OVN_BUILD_VERSION__/$PF9_OVN_BUILD_VERSION/g" $ROOT/debian/changelog
 sed -i "s/__PF9_OVN_BUILD_VERSION__/$PF9_OVN_BUILD_VERSION/g" $ROOT/configure.ac
@@ -62,6 +62,10 @@ mkdir -p $ARTIFACT_DIR
 mv -v "$ROOT"/*.deb $ARTIFACT_DIR
 mv -v ../*.deb $ARTIFACT_DIR
 
+git reset HEAD --hard
+git clean -x
+
+cd $ROOT/ovs
 git reset HEAD --hard
 git clean -x
 

--- a/build-aux/build-debs.sh
+++ b/build-aux/build-debs.sh
@@ -2,6 +2,7 @@ set -x
 
 source pf9-version/pf9-version.rc
 
+TEAMCITY_ROOT="$(pwd)"
 ROOT="$(pwd)/pf9-ovn"
 
 make distclean
@@ -56,10 +57,13 @@ export OVSDIR OVSBUILDDIR EXTRA_CONFIGURE_OPTS="--with-ovs-build=$OVSBUILDDIR"
 
 DEB_BUILD_OPTIONS=nocheck dpkg-buildpackage -b -us -uc
 
-ARTIFACT_DIR="$ROOT/pkgs/$UBUNTU_VERSION"
+ARTIFACT_DIR="$TEAMCITY_ROOT/pkgs/$UBUNTU_VERSION"
 mkdir -p $ARTIFACT_DIR
 mv -v "$ROOT"/*.deb $ARTIFACT_DIR
 mv -v ../*.deb $ARTIFACT_DIR
+
+git reset HEAD --hard
+git clean -x
 
 cd $ARTIFACT_DIR
 dpkg-scanpackages . /dev/null | gzip -9c > Packages.gz

--- a/build-aux/build-debs.sh
+++ b/build-aux/build-debs.sh
@@ -62,12 +62,14 @@ mkdir -p $ARTIFACT_DIR
 mv -v "$ROOT"/*.deb $ARTIFACT_DIR
 mv -v ../*.deb $ARTIFACT_DIR
 
+# clean up the build
+cd $ROOT
 git reset HEAD --hard
-git clean -x
+git clean -fdx
 
 cd $ROOT/ovs
 git reset HEAD --hard
-git clean -x
+git clean -fdx
 
 cd $ARTIFACT_DIR
 dpkg-scanpackages . /dev/null | gzip -9c > Packages.gz


### PR DESCRIPTION
The teamcity build and the deb build script have been updated to allow for ubuntu24 package builds to successfully complete. Earlier the ubuntu22 build would complete (OVN and OVS), ubuntu24 ovs build would complete, but ubuntu 24 OVN build would fail because of the u22 build having dirtied the file tree. I have added cleanup to the git repositories to ensure that both u22 and u24 builds get the tree in a pristine state and will reach completion.