### PR TITLE
PCD-5213 PCD-5081 - Fixed ubuntu OS upgrade by editing the versioning for OVN and OVS

### DIFF
--- a/build-aux/build-debs.sh
+++ b/build-aux/build-debs.sh
@@ -18,6 +18,7 @@ sed -i "s/__PF9_OVN_BUILD_VERSION__/$PF9_OVN_BUILD_VERSION+$UBUNTU_VERSION/g" $R
 
 PF9_OVS_BUILD_VERSION=1:3.3.1-pf9-$PF9_VERSION-$BUILD_NUMBER
 printf '%s' "$PF9_OVS_BUILD_VERSION" >> $ROOT/ovn-deb-version.txt
+cat ovn-deb-version.txt
 
 sed -i "s/3.3.1-1/$PF9_OVS_BUILD_VERSION+$UBUNTU_VERSION/g" $ROOT/ovs/debian/changelog
 

--- a/build-aux/build-debs.sh
+++ b/build-aux/build-debs.sh
@@ -18,7 +18,6 @@ sed -i "s/__PF9_OVN_BUILD_VERSION__/$PF9_OVN_BUILD_VERSION+$UBUNTU_VERSION/g" $R
 
 PF9_OVS_BUILD_VERSION=1:3.3.1-pf9-$PF9_VERSION-$BUILD_NUMBER
 printf '%s' "$PF9_OVS_BUILD_VERSION" >> $TEAMCITY_ROOT/ovn-deb-version.txt
-cat ovn-deb-version.txt
 
 sed -i "s/3.3.1-1/$PF9_OVS_BUILD_VERSION+$UBUNTU_VERSION/g" $ROOT/ovs/debian/changelog
 

--- a/build-aux/build-debs.sh
+++ b/build-aux/build-debs.sh
@@ -20,7 +20,12 @@ PF9_OVS_BUILD_VERSION=1:3.3.1-pf9-$PF9_VERSION-$BUILD_NUMBER
 printf '%s' "$PF9_OVS_BUILD_VERSION" >> $ROOT/ovn-deb-version.txt
 
 sed -i "s/3.3.1-1/$PF9_OVS_BUILD_VERSION+$UBUNTU_VERSION/g" $ROOT/ovs/debian/changelog
-sed -i "s/3.3.1/$PF9_OVS_BUILD_VERSION+$UBUNTU_VERSION/g" $ROOT/ovs/configure.ac
+
+# Python setuptools (used in OVS build) requires PEP 440 compliant version.
+# We sanitize the version by removing epoch and replacing hyphens with dots or +
+# 1:3.3.1-pf9... -> 3.3.1+pf9...
+PF9_OVS_PYTHON_VERSION=$(echo "$PF9_OVS_BUILD_VERSION" | sed 's/^1://; s/-/./g; s/3.3.1./3.3.1+/')
+sed -i "s/3.3.1/$PF9_OVS_PYTHON_VERSION.$UBUNTU_VERSION/g" $ROOT/ovs/configure.ac
 
 apt-get update
 DEBIAN_FRONTEND=noninteractive apt-get install -y \

--- a/build-aux/build-debs.sh
+++ b/build-aux/build-debs.sh
@@ -11,7 +11,7 @@ UBUNTU_VERSION=$1
 
 
 PF9_OVN_BUILD_VERSION=1:24.03.2-pf9-$PF9_VERSION-$BUILD_NUMBER
-printf '%s\n' "$PF9_OVN_BUILD_VERSION" > $ROOT/ovn-deb-version.txt
+printf '%s\n' "$PF9_OVN_BUILD_VERSION" > $TEAMCITY_ROOT/ovn-deb-version.txt
 
 sed -i "s/__PF9_OVN_BUILD_VERSION__/$PF9_OVN_BUILD_VERSION+$UBUNTU_VERSION/g" $ROOT/debian/changelog
 sed -i "s/__PF9_OVN_BUILD_VERSION__/$PF9_OVN_BUILD_VERSION+$UBUNTU_VERSION/g" $ROOT/configure.ac

--- a/build-aux/build-debs.sh
+++ b/build-aux/build-debs.sh
@@ -17,7 +17,7 @@ sed -i "s/__PF9_OVN_BUILD_VERSION__/$PF9_OVN_BUILD_VERSION+$UBUNTU_VERSION/g" $R
 sed -i "s/__PF9_OVN_BUILD_VERSION__/$PF9_OVN_BUILD_VERSION+$UBUNTU_VERSION/g" $ROOT/configure.ac
 
 PF9_OVS_BUILD_VERSION=1:3.3.1-pf9-$PF9_VERSION-$BUILD_NUMBER
-printf '%s' "$PF9_OVS_BUILD_VERSION" >> $ROOT/ovn-deb-version.txt
+printf '%s' "$PF9_OVS_BUILD_VERSION" >> $TEAMCITY_ROOT/ovn-deb-version.txt
 cat ovn-deb-version.txt
 
 sed -i "s/3.3.1-1/$PF9_OVS_BUILD_VERSION+$UBUNTU_VERSION/g" $ROOT/ovs/debian/changelog

--- a/build-aux/build-debs.sh
+++ b/build-aux/build-debs.sh
@@ -10,11 +10,17 @@ make distclean
 UBUNTU_VERSION=$1
 
 
-PF9_OVN_BUILD_VERSION=24.03.2-pf9-$PF9_VERSION-$BUILD_NUMBER
-printf '%s' "$PF9_OVN_BUILD_VERSION" > $TEAMCITY_ROOT/ovn-deb-version.txt
+PF9_OVN_BUILD_VERSION=1:24.03.2-pf9-$PF9_VERSION-$BUILD_NUMBER
+printf '%s\n' "$PF9_OVN_BUILD_VERSION" > $ROOT/ovn-deb-version.txt
 
-sed -i "s/__PF9_OVN_BUILD_VERSION__/$PF9_OVN_BUILD_VERSION/g" $ROOT/debian/changelog
-sed -i "s/__PF9_OVN_BUILD_VERSION__/$PF9_OVN_BUILD_VERSION/g" $ROOT/configure.ac
+sed -i "s/__PF9_OVN_BUILD_VERSION__/$PF9_OVN_BUILD_VERSION+$UBUNTU_VERSION/g" $ROOT/debian/changelog
+sed -i "s/__PF9_OVN_BUILD_VERSION__/$PF9_OVN_BUILD_VERSION+$UBUNTU_VERSION/g" $ROOT/configure.ac
+
+PF9_OVS_BUILD_VERSION=1:3.3.1-pf9-$PF9_VERSION-$BUILD_NUMBER
+printf '%s' "$PF9_OVS_BUILD_VERSION" >> $ROOT/ovn-deb-version.txt
+
+sed -i "s/3.3.1-1/$PF9_OVS_BUILD_VERSION+$UBUNTU_VERSION/g" $ROOT/ovs/debian/changelog
+sed -i "s/3.3.1/$PF9_OVS_BUILD_VERSION+$UBUNTU_VERSION/g" $ROOT/ovs/configure.ac
 
 apt-get update
 DEBIAN_FRONTEND=noninteractive apt-get install -y \

--- a/build-aux/xml2nroff
+++ b/build-aux/xml2nroff
@@ -97,7 +97,7 @@ def manpage_to_nroff(xml_file, subst, include_path, version=None):
 ''' % (nroff.text_to_nroff(program),
        nroff.text_to_nroff(section),
        nroff.text_to_nroff(title),
-       nroff.text_to_nroff(version))
+       nroff.text_to_nroff(version, escape_dot=False))
 
     s += nroff.block_xml_to_nroff(doc.childNodes) + "\n"
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,7 @@
 ovn (__PF9_OVN_BUILD_VERSION__) unstable; urgency=medium
-
-* Platform9 Systems
-  * ovn-northd: added changes to support l2 only ports
-  * container: added support to build ovn container using custom changes
+   [ Platform9 Systems ]
+   * ovn-northd: added changes to support l2 only ports
+   * container: added support to build ovn container using custom changes
 
  -- Platform9 Systems <info@platform9.com>  Tue, 16 Dec 2025 22:00:00 -0800
 


### PR DESCRIPTION
Added custom versioning for OVS, added an epoch to the OVN/OVS version to ensure that u22->u24 OS upgrades can occur successfully with custom OVN/OVS packages