### PR TITLE
OVN Binding profile for l2-port -- backport

### DIFF
--- a/northd/northd.c
+++ b/northd/northd.c
@@ -8150,7 +8150,8 @@ is_vif_lsp(const struct nbrec_logical_switch_port *nbsp)
 }
 
 /* Returns true if a VIF should be treated as L2-only (no L3 addressing and
- * port security disabled). This matches the common "unknown addresses" +
+ * port security disabled). Requires explicit "l2-port" external_id to be
+ * set by Neutron, in addition to the common "unknown addresses" +
  * empty port_security case. */
 static bool
 port_is_l2_only_port(const struct ovn_port *op)
@@ -8168,13 +8169,16 @@ port_is_l2_only_port(const struct ovn_port *op)
 
     bool has_no_fixed_ip = op->has_unknown;
     bool port_sec_off = (op->nbsp->n_port_security == 0);
+    bool l2_port_extid = smap_get_bool(&op->nbsp->external_ids,
+                                       "l2-port", false);
 
-    VLOG_DBG("port_is_l2_only_port: %s has_no_fixed_ip=%s port_sec_off=%s",
+    VLOG_DBG("port_is_l2_only_port: %s has_no_fixed_ip=%s port_sec_off=%s l2_port_extid=%s",
              op->json_key,
              has_no_fixed_ip ? "true" : "false",
-             port_sec_off ? "true" : "false");
+             port_sec_off ? "true" : "false",
+             l2_port_extid ? "true" : "false");
 
-    return has_no_fixed_ip && port_sec_off;
+    return has_no_fixed_ip && port_sec_off && l2_port_extid;
 }
 
 /* Return the logical port key without surrounding quotes.


### PR DESCRIPTION
Added logic to make l2 port check stricter, issues seen on scale testbed pointing misclassification of router ports as L2 ports.

* Add l2-port flag

* Make the check more strict