### PR TITLE
[PCD-4934] Add l2only mac spoofing prevention, and prevent flooding f…

### DIFF
--- a/northd/northd.c
+++ b/northd/northd.c
@@ -8233,6 +8233,70 @@ add_l2only_flood_all(struct ovn_port *p, struct hmap *lflows)
     ds_destroy(&match);
 }
 
+/* Allow VIF traffic if and only if eth.src matches the port MAC.
+ * This preserves MAC anti-spoofing while realxing IP/ARP restrictions. 
+*/
+static void
+add_l2only_mac_spoofing_prevention(struct ovn_port *p, struct hmap *lflows, const char* src_mac){
+    if (!p || !p->od || !p->nbsp) {
+        VLOG_DBG("port is null, skipping...");
+        return;
+    }
+
+    if (!port_is_l2_only_port(p)) {
+        return;
+    }
+
+    struct ds match = DS_EMPTY_INITIALIZER;
+    struct ds action = DS_EMPTY_INITIALIZER;
+
+    /* Use src_mac as the allowed MAC set for this VIF. */
+    VLOG_DBG("Adding mac_spoofing prevention to port %s, mac_address: %s", p->key, src_mac);
+
+    struct eth_addr ea;
+    if (eth_addr_from_string(src_mac, &ea)) {
+        ds_clear(&match);
+        ds_clear(&action);
+        ds_put_format(&match, "inport == \"%s\" && eth.src != %s", p->key, src_mac);
+        ds_put_format(&action, "%s=1; next;", REGBIT_PORT_SEC_DROP);
+        ovn_lflow_add_with_hint(
+            lflows, p->od,
+            S_SWITCH_IN_CHECK_PORT_SEC,
+            110,                       /* higher than minimal_portsec_bypass rules */
+            ds_cstr(&match),
+            ds_cstr(&action),
+            &p->nbsp->header_, NULL
+        );
+
+        /* ARP: ensure arp.sha matches MAC */
+        ds_clear(&match);
+        ds_put_format(&match, "inport == \"%s\" && eth.type == 0x0806 && arp.sha != %s", p->key, src_mac);
+        ovn_lflow_add_with_hint(lflows, p->od,
+            S_SWITCH_IN_CHECK_PORT_SEC,
+            110,                        /* higher than minimal_portsec_bypass rules */
+            ds_cstr(&match),
+            ds_cstr(&action),
+            &p->nbsp->header_, NULL
+        );
+
+        /* Drop wherever REGBIT_PORT_SEC_DROP=1 with a higher priority than minimal_portsec_bypass */
+        ds_clear(&match);
+        ds_put_format(&match, "inport == \"%s\" && %s == 1", p->key, REGBIT_PORT_SEC_DROP);
+        ovn_lflow_add_with_hint(lflows, p->od,
+            S_SWITCH_IN_APPLY_PORT_SEC,
+            110,                        /* higher than minimal_portsec_bypass rules */
+            ds_cstr(&match),
+            debug_drop_action(),
+            &p->nbsp->header_, NULL
+        );
+    }else {
+        VLOG_WARN("invalid mac_address: %s for port %s, skipping mac spoofing prevention...", src_mac, p->key);
+    }
+
+    ds_destroy(&match);
+    ds_destroy(&action);
+}
+
 /* Minimal and scoped port-security bypass for L2-only VIFs.
  * - Only affects this single VIF.
  * - Keeps stage ordering intact (still runs later stages).
@@ -16097,7 +16161,6 @@ build_lswitch_and_lrouter_flows(
     const struct chassis_features *features,
     const char *svc_monitor_mac)
 {
-
     char *svc_check_match = xasprintf("eth.dst == %s", svc_monitor_mac);
 
     if (parallelization_state == STATE_USE_PARALLELIZATION) {
@@ -16211,18 +16274,30 @@ build_lswitch_and_lrouter_flows(
          *
          * Both are low/specific priority so the standard pipeline keeps
          * taking precedence when applicable. */
+        VLOG_DBG("processing l2_only ports...");
         HMAP_FOR_EACH (op, key_node, lsi.ls_ports) {
             if (!op || !op->od || !op->nbsp) {
+                VLOG_DBG("port is null, skipping.");
                 continue;
             }
             if (!port_is_l2_only_port(op)) {
+                VLOG_DBG("port is not l2_only, skipping.");
                 continue;
             }
 
-            VLOG_INFO("L2-only VIF detected on %s; adding port-sec bypass + uu fallback",
+            VLOG_DBG("L2-only VIF detected on %s; adding port-sec bypass + uu fallback",
                       op->json_key);
+            
+            bool allow_forged_mac = smap_get_bool(&op->nbsp->external_ids, "pf9-allow-mac-forged-transmits", false);
+            char *src_mac = smap_get_def(&op->nbsp->external_ids, "pf9-l2port-src-mac", "");
+
+            VLOG_DBG("port: %s; src_mac: %s; allow_forged_mac: %s", op->key, src_mac, allow_forged_mac ? "true" : "false");
+
             add_minimal_portsec_bypass(op, lsi.lflows);
             add_l2only_flood_all(op, lsi.lflows);
+            if (!allow_forged_mac && src_mac && src_mac[0]) {
+                add_l2only_mac_spoofing_prevention(op, lflows, src_mac);
+            }
         }
         stopwatch_stop(LFLOWS_PORTS_STOPWATCH_NAME, time_msec());
 /* PF9 stop */


### PR DESCRIPTION
https://platform9.atlassian.net/browse/PCD-4934
## Summary
- Added l2only mac spoofing prevention which can be toggled on and off per port basis.
- Added flow to prevent flooding for East-West traffic on l2only networks.

## Testing Notes
Complete Dev Testing Notes: https://platform9.atlassian.net/browse/PCD-4934?focusedCommentId=179808

### OVN Traces
```bash
# OVN trace for Spoofed Mac (Real Mac: fa:16:3e:ee:81:ec)
root@ovn-ovsdb-sb-0:~# ovn-trace --summary neutron-6fa0589e-6923-484c-a6c5-d258b094c4ff 'inport == "08a52021-ca52-4983-a807-ab834291d9fe" && eth.src == fa:16:3e:d2:4a:61 && eth.dst == fa:16:3e:64:af:f4 && ip4.src == 10.5.0.5 && ip4.dst == 10.5.0.1'
# ip,reg14=0x9,vlan_tci=0x0000,dl_src=fa:16:3e:d2:4a:61,dl_dst=fa:16:3e:64:af:f4,nw_src=10.5.0.5,nw_dst=10.5.0.1,nw_proto=0,nw_tos=0,nw_ecn=0,nw_ttl=0,nw_frag=no
ingress(dp="l2only-01", inport="l2only-vm-01-l2only-01-port") {
    reg0[15] = 1;
    next;
    drop;
};

# OVN trace for Non-Spoofed Mac (Also you can see packet is not flooded to all ports)
root@ovn-ovsdb-sb-0:~# ovn-trace --summary neutron-6fa0589e-6923-484c-a6c5-d258b094c4ff --detailed 'inport == "08a52021-ca52-4983-a807-ab834291d9fe" && eth.src == fa:16:3e:ee:81:ec && eth.dst == fa:16:3e:64:af:f4 && ip4.src == 10.5.0.5 && ip4.dst == 10.5.0.1'
# ip,reg14=0x9,vlan_tci=0x0000,dl_src=fa:16:3e:ee:81:ec,dl_dst=fa:16:3e:64:af:f4,nw_src=10.5.0.5,nw_dst=10.5.0.1,nw_proto=0,nw_tos=0,nw_ecn=0,nw_ttl=0,nw_frag=no
# Detailed trace.

ingress(dp="l2only-01", inport="l2only-vm-01-l2only-01-port")
-------------------------------------------------------------
 0. ls_in_check_port_sec (northd.c:8346): inport == "l2only-vm-01-l2only-01-port", priority 100, uuid 21f16020
    next;
 1. ls_in_apply_port_sec (northd.c:8349): inport == "l2only-vm-01-l2only-01-port", priority 100, uuid 4e69372a
    next;
 2. ls_in_lookup_fdb (northd.c:5774): inport == "l2only-vm-01-l2only-01-port", priority 100, uuid a2bbf671
    reg0[11] = lookup_fdb(inport, eth.src);
    /* MAC lookup for fa:16:3e:64:af:f4 found in FDB. */
    next;
27. ls_in_l2_lkup (northd.c:8255): eth.dst == fa:16:3e:64:af:f4, priority 110, uuid ec629436
    outport = "new-port-test-01";
    output;

egress(dp="l2only-01", inport="l2only-vm-01-l2only-01-port", outport="new-port-test-01")
----------------------------------------------------------------------------------------
 9. ls_out_check_port_sec (northd.c:8356): outport == "new-port-test-01", priority 100, uuid fc4af173
    next;
10. ls_out_apply_port_sec (northd.c:8359): outport == "new-port-test-01", priority 100, uuid 93726542
    output;
    /* output to "new-port-test-01", type "" */
# Summary trace.
ingress(dp="l2only-01", inport="l2only-vm-01-l2only-01-port") {
    next;
    next;
    reg0[11] = lookup_fdb(inport, eth.src);
    /* MAC lookup for fa:16:3e:64:af:f4 found in FDB. */
    next;
    outport = "new-port-test-01";
    output;
    egress(dp="l2only-01", inport="l2only-vm-01-l2only-01-port", outport="new-port-test-01") {
        next;
        output;
        /* output to "new-port-test-01", type "" */;
    };
};
```

## Testing on VMs
```bash
# Spoofed Mac
ubuntu@l2only-vm-01:~$ sudo arping -c 1 -S 10.0.0.240 -s de:ad:be:ef:00:01 10.0.0.241
ARPING 10.0.0.241
Timeout

--- 10.0.0.241 statistics ---
1 packets transmitted, 0 packets received, 100% unanswered (0 extra)

# Real Mac
ubuntu@l2only-vm-01:~$ sudo arping -c 1 -S 10.0.0.240 -s fa:16:3e:ee:81:ec 10.0.0.241
ARPING 10.0.0.241
42 bytes from fa:16:3e:61:9d:33 (10.0.0.241): index=0 time=637.517 usec

--- 10.0.0.241 statistics ---
1 packets transmitted, 1 packets received,   0% unanswered (0 extra)
rtt min/avg/max/std-dev = 0.638/0.638/0.638/0.000 ms

# Allow Mac Spoofing for this Port
ubuntu@l2only-vm-01:~$ os port set --binding-profile '{"pf9-allow-mac-forged-transmits": true}' 08a52021-ca52-4983-a807-ab834291d9fe

# Mac Spoofing working now
ubuntu@l2only-vm-01:~$ sudo arping -c 1 -S 10.0.0.240 -s fa:16:3e:ee:81:ec 10.0.0.241
ARPING 10.0.0.241
42 bytes from fa:16:3e:61:9d:33 (10.0.0.241): index=0 time=637.517 usec

--- 10.0.0.241 statistics ---
1 packets transmitted, 1 packets received,   0% unanswered (0 extra)
rtt min/avg/max/std-dev = 0.638/0.638/0.638/0.000 ms
```